### PR TITLE
[PLUGIN-1771] Add Streaming support for excel source 

### DIFF
--- a/core-plugins/pom.xml
+++ b/core-plugins/pom.xml
@@ -174,14 +174,34 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.15.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.26.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
-      <version>3.12</version>
+      <version>5.2.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi-ooxml</artifactId>
-      <version>3.11</version>
+      <version>5.2.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.pjfanning</groupId>
+      <artifactId>excel-streaming-reader</artifactId>
+      <version>4.2.1</version>
+    </dependency>
+    <dependency>
+       <groupId>com.github.pjfanning</groupId>
+       <artifactId>poi-shared-strings</artifactId>
+       <version>2.8.0</version>
     </dependency>
     <dependency>
       <scope>test</scope>


### PR DESCRIPTION
##  Add Streaming support for excel source

Jira : [PLUGIN-1771](https://cdap.atlassian.net/browse/PLUGIN-1771)

### Description

Excel plugin consumes huge memory when reading large files.
This is due to it loading the complete file in it's memory.

This PR adds streaming support `xlxs` filetype.
- As we won't be able to stream old `xls` binary based format we use magic bytes to detect the filetype.

### UI Field

- No Changes made to widget json.

### Docs

- No Changes made to docs.

### Code change

- Modified `ExcelInputFormat.java`

### Unit Tests

- No Changes made to unit tests.