### PR TITLE
[PLUGIN-1867] Error management changes for CSV parser

### DIFF
--- a/transform-plugins/src/main/java/io/cdap/plugin/CSVParser.java
+++ b/transform-plugins/src/main/java/io/cdap/plugin/CSVParser.java
@@ -26,6 +26,9 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.data.schema.Schema.Field;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.FailureCollector;
@@ -176,16 +179,20 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
         break;
 
       default:
-        throw new IllegalArgumentException("Format {} specified is not one of the allowed format. Allowed formats are" +
-                                             "DEFAULT, EXCEL, MYSQL, RFC4180, Pipe Delimited and Tab Delimited or " +
-                                             "Custom");
+        String error = String.format("Format %s specified is not one of the allowed format. Allowed formats are " +
+                                       "DEFAULT, EXCEL, MYSQL, RFC4180, Pipe Delimited and Tab Delimited or Custom",
+                                     csvFormatString);
+        throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+                                                    error, error, ErrorType.USER, false, null);
     }
 
     try {
       outSchema = Schema.parseJson(config.schema);
       fields = outSchema.getFields();
     } catch (IOException e) {
-      throw new IllegalArgumentException("Format of schema specified is invalid. Please check the format.");
+      String error = "Format of schema specified is invalid. Please check the format.";
+      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+                                                  error, error, ErrorType.USER, false, null);
     }
   }
 
@@ -224,6 +231,13 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
       } else if (record == null) {
         builder.set(name, null);
       } else {
+        if (i >= record.size()) {
+          String error = String.format("Number of values in the record : %s are not as per output schema. " +
+                                         "Expected %d values, but found only %d values",
+                                       record, fields.size(), record.size());
+          throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+                                                      error, error, ErrorType.USER, false, null);
+        }
         String val = record.get(i);
         Schema fieldSchema = field.getSchema();
 
@@ -235,10 +249,12 @@ public final class CSVParser extends Transform<StructuredRecord, StructuredRecor
             builder.set(field.getName(), "");
           } else if (!isNullable) {
             // otherwise, error out
-            throw new IllegalArgumentException(String.format(
+            String error = String.format(
               "Field #%d (named '%s') is of non-nullable type '%s', " +
                 "but was parsed as an empty string for CSV record '%s'",
-              i, field.getName(), field.getSchema().getType(), record));
+              i, field.getName(), field.getSchema().getType(), record);
+            throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+                                                        error, error, ErrorType.USER, false, null);
           }
         } else {
           builder.convertAndSet(field.getName(), val);


### PR DESCRIPTION
Description
Error Management for CSVParser transform plugin exceptions
https://cdap.atlassian.net/browse/PLUGIN-1867

Code change
Modified CSVParser.java

Tests
Test Case - tested with valid and invalid scenarios

###  1. Success
<img width="1409" alt="Screenshot 2025-02-20 at 4 25 00 PM" src="https://github.com/user-attachments/assets/070b3e51-a0e2-44cd-b933-bf9ede1a8189" />


### 2. Missing CSV values
<img width="1440" alt="Screenshot 2025-02-20 at 7 13 34 PM" src="https://github.com/user-attachments/assets/75a878ef-eb04-4396-ac03-f574af7d5faf" />
<img width="1224" alt="Screenshot 2025-02-20 at 7 13 45 PM" src="https://github.com/user-attachments/assets/054b6882-1fbd-4a3a-b592-115feab68d85" />
<img width="1414" alt="Screenshot 2025-02-20 at 7 14 03 PM" src="https://github.com/user-attachments/assets/e11fd3f2-8a1d-4b7d-bb64-e42119824536" />


### 3. Empty CSV values
<img width="1425" alt="Screenshot 2025-02-20 at 4 22 03 PM" src="https://github.com/user-attachments/assets/ce881364-42a1-4463-b7d8-f179317891d2" />
<img width="1240" alt="Screenshot 2025-02-20 at 4 22 16 PM" src="https://github.com/user-attachments/assets/d5f8aa46-d0b1-4750-8af0-7d60ba802737" />
<img width="1412" alt="Screenshot 2025-02-20 at 4 22 42 PM" src="https://github.com/user-attachments/assets/70413365-5e74-4f77-89a3-9c81b11d2fba" />
